### PR TITLE
HCurlNoGrads triangular faces

### DIFF
--- a/divfree/TPZCompElHCurlNoGrads.cpp
+++ b/divfree/TPZCompElHCurlNoGrads.cpp
@@ -170,17 +170,21 @@ int TPZCompElHCurlNoGrads<TSHAPE>::NConnectShapeF(int icon, int order) const
       return 1;
     }
     else if(side < TSHAPE::NCornerNodes + nEdges + nFaces){//face connect
-      return 0;
-      // switch(TSHAPE::Type(side)){
-      // case ETriangle://triangular face
-      //   return (order - 1) * (order+1);
-      // case EQuadrilateral://quadrilateral face
-      //   return 2 * order * (order+1);
-      // default:
-      //   PZError<<__PRETTY_FUNCTION__<<" error."<<std::endl;
-      //   DebugStop();
-      //   return 0;
-      // }
+      switch(TSHAPE::Type(side)){
+      case ETriangle://triangular face
+        /**
+           we remove one internal function for each h1 face function of order k+1
+           since there are (k-1)(k-2)/2 functions per face in a face with order k,
+           we remove k(k-1)/2.
+           so:
+           (k-1)*(k+1)-k*(k-1)/2
+        */
+        return (order - 1) * (order+2) / 2;
+      default:
+        PZError<<__PRETTY_FUNCTION__<<" error. Not yet implemented"<<std::endl;
+        DebugStop();
+        return 0;
+      }
     }
     else{//internal connect (3D element only)
       return 0;

--- a/divfree/TPZCompElHCurlNoGrads.h
+++ b/divfree/TPZCompElHCurlNoGrads.h
@@ -59,6 +59,19 @@ protected:
   //! Fills data.sol and data.curlsol.
   template<class TVar>
   void ReallyComputeSolutionT(TPZMaterialDataT<TVar> &data);
+  /**
+     @brief Given the original indices of functions of a a HCurl element,
+     calculates the subset corresponding to
+     the filtered higher-order (face, interior) functions.
+     @param[in] firstHCurlFunc index of first Hurl function corresponding to a given connect.
+     @param[in] conOrders connect orders.
+     @param[in] filteredFuncs indices of desired of Hcurl functions.
+   */
+  static void HighOrderFunctionsFilter(
+    const TPZVec<int> &firstHCurlFunc,
+    const TPZVec<int> &conOrders,
+    TPZVec<int> &filteredHCurlFuncs);
+    
   
 };
 #endif /* _TPZCOMPELHCURLNOGRADS_H_ */


### PR DESCRIPTION
This PR introduces `void TPZCompElHCurlNoGrads<TSHAPE>::HighOrderFunctionsFilter`, which filters the high order functions of a given HCurl element so that the gradients of the corresponding H1 elements cannot be represented.

Now, it only deals with triangular faces. Internal functions (for tetrahedra) are coming next, and then quadrilateral faces.

For a HCurl element of order `k`, there are:
- `3(k-1)` phi_fe functions (based on edge h1 functions)
- `2(k-2)` phi_fi functions (based on face h1 functions)

We currently remove:
- `(k-1)` phi_fe functions (i.e., we skip one function introduced in each polynomial order)
- `(k-1)(k-2)/2` phi_fi functions (i.e., we take half of the functions introduced in each polynomial order)
Therefore we have removed `k(k-1)/2` functions, which is exactly the number of face functions of a H1 element of order `k+1`.